### PR TITLE
Make Example obey the guidance in Remarks

### DIFF
--- a/snippets/csharp/VS_Snippets_Misc/system.net.http.httpclient/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_Misc/system.net.http.httpclient/cs/source.cs
@@ -7,28 +7,27 @@ using System.Threading.Tasks;
 class HttpClient_Example
 {
 // <Snippet1>
+   // HttpClient is intended to be instantiated once per application, rather than per-use. See Remarks.
+   static readonly HttpClient client = new HttpClient();
+    
    static async Task Main()
    {
-      // Create a New HttpClient object and dispose it when done, so the app doesn't leak resources
-      using (HttpClient client = new HttpClient())
-      {
-         // Call asynchronous network methods in a try/catch block to handle exceptions
-         try	
-         {
-            HttpResponseMessage response = await client.GetAsync("http://www.contoso.com/");
-            response.EnsureSuccessStatusCode();
-            string responseBody = await response.Content.ReadAsStringAsync();
-            // Above three lines can be replaced with new helper method below
-            // string responseBody = await client.GetStringAsync(uri);
+     // Call asynchronous network methods in a try/catch block to handle exceptions
+     try	
+     {
+        HttpResponseMessage response = await client.GetAsync("http://www.contoso.com/");
+        response.EnsureSuccessStatusCode();
+        string responseBody = await response.Content.ReadAsStringAsync();
+        // Above three lines can be replaced with new helper method below
+        // string responseBody = await client.GetStringAsync(uri);
 
-            Console.WriteLine(responseBody);
-         }  
-         catch(HttpRequestException e)
-         {
-            Console.WriteLine("\nException Caught!");	
-            Console.WriteLine("Message :{0} ",e.Message);
-         }
-      }
+        Console.WriteLine(responseBody);
+     }  
+     catch(HttpRequestException e)
+     {
+        Console.WriteLine("\nException Caught!");	
+        Console.WriteLine("Message :{0} ",e.Message);
+     }
    }
 // </Snippet1>			
 }


### PR DESCRIPTION
The Example should reflect the guidance in the Remarks: that HttpClient is intended to be instantiated once per application, rather than per-use. Otherwise, it's setting a bad example.

## Summary

Made the example use a static instance of httpClient instead of the "create-and-dispose inside the Method" pattern.

Fixes dotnet/dotnet-api-docs#1910
